### PR TITLE
feat: add samples to Java README

### DIFF
--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -18,6 +18,9 @@ Java idiomatic client for [{{metadata['repo']['name_pretty']}}][product-docs].
 
 If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
 ```xml
+{% if 'snippets' in metadata and metadata['snippets'][metadata['repo']['name'] + '_install_with_bom'] -%}
+{{ metadata['snippets'][metadata['repo']['name'] + '_install_with_bom'] }}
+{% else -%}
 <dependencyManagement>
   <dependencies>
     <dependency>
@@ -29,13 +32,13 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
     </dependency>
   </dependencies>
 </dependencyManagement>
-
 <dependencies>
   <dependency>
     <groupId>{{ group_id }}</groupId>
     <artifactId>{{ artifact_id }}</artifactId>
   </dependency>
 </dependencies>
+{% endif -%}
 ```
 
 [//]: # ({x-version-update-start:{{ artifact_id }}:released})
@@ -43,11 +46,15 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
 If you are using Maven without BOM, add this to your dependencies:
 
 ```xml
+{% if 'snippets' in metadata and metadata['snippets'][metadata['repo']['name'] + '_install_without_bom'] -%}
+{{ metadata['snippets'][metadata['repo']['name'] + '_install_without_bom'] }}
+{% else -%}
 <dependency>
   <groupId>{{ group_id }}</groupId>
   <artifactId>{{ artifact_id }}</artifactId>
   <version>{{ metadata['latest_version'] }}</version>
 </dependency>
+{% endif -%}
 ```
 
 If you are using Gradle, add this to your dependencies
@@ -92,6 +99,18 @@ use this {{metadata['repo']['name_pretty']}} Client Library.
 
 {% if 'partials' in metadata and metadata['partials']['custom_content'] -%}
 {{ metadata['partials']['custom_content'] }}
+{% endif %}
+
+{% if metadata['samples']|length %}
+## Samples
+
+Samples are in the [`samples/`](https://github.com/{{  metadata['repo']['repo'] }}/tree/master/samples) directory. The samples' `README.md`
+has instructions for running the samples.
+
+| Sample                      | Source Code                       | Try it |
+| --------------------------- | --------------------------------- | ------ |
+{% for sample in metadata['samples'] %}| {{ sample.title }} | [source code](https://github.com/{{ metadata['repo']['repo']  }}/blob/master/samples/{{ sample.file }}) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/{{ metadata['repo']['repo'] }}&page=editor&open_in_editor={{ sample.file }}) |
+{% endfor %}
 {% endif %}
 
 ## Troubleshooting
@@ -176,3 +195,4 @@ Java 11 | [![Kokoro CI][kokoro-badge-image-5]][kokoro-badge-link-5]
 {% if metadata['repo']['requires_billing'] %}[enable-billing]: https://cloud.google.com/apis/docs/getting-started#enabling_billing{% endif %}
 {% if metadata['repo']['api_id'] %}[enable-api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
 [libraries-bom]: https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -77,7 +77,7 @@ has instructions for running the samples.
 
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
-{% for sample in metadata['samples'] %}| {{ sample.title }} | [source code](https://github.com/{{ metadata['repo']['repo']  }}/blob/master/samples/{{ sample.file }}) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/{{ metadata['repo']['repo'] }}&page=editor&open_in_editor=samples/{{ sample.file }},samples/README.md) |
+{% for sample in metadata['samples'] %}| {{ sample.title }} | [source code](https://github.com/{{ metadata['repo']['repo']  }}/blob/master/{{ sample.file }}) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/{{ metadata['repo']['repo'] }}&page=editor&open_in_editor={{ sample.file }},samples/README.md) |
 {% endfor %}
 {% endif %}
 {% if metadata['repo']['client_documentation'] %}

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -18,7 +18,7 @@ import xml.etree.ElementTree as ET
 import requests
 import synthtool as s
 import synthtool.gcp as gcp
-from synthtool.gcp import common
+from synthtool.gcp import common, samples, snippets
 from synthtool import cache
 from synthtool import log
 from synthtool import shell
@@ -343,6 +343,11 @@ def common_templates(excludes: List[str] = [], **kwargs) -> None:
 
     metadata["latest_bom_version"] = latest_maven_version(
         group_id="com.google.cloud", artifact_id="libraries-bom",
+    )
+
+    metadata["samples"] = samples.all_samples(["samples/**/src/main/java/**/*.java"])
+    metadata["snippets"] = snippets.all_snippets(
+        ["samples/**/src/main/java/**/*.java", "samples/**/pom.xml"]
     )
 
     kwargs["metadata"] = metadata

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -68,29 +68,6 @@ def test_release_quality_badge():
     assert "This library is considered to be in **beta**" in result
 
 
-def test_load_samples():
-    cwd = os.getcwd()
-    os.chdir(FIXTURES)
-
-    common_templates = common.CommonTemplates()
-    metadata = {}
-    common_templates._load_samples(metadata)
-    # should have loaded samples.
-    assert metadata["samples"][3]["title"] == "Requester Pays"
-    assert metadata["samples"][3]["file"] == "requesterPays.js"
-    assert len(metadata["samples"]) == 4
-    # should have loaded the special quickstart sample (ignoring header).
-    assert "ID of the Cloud Bigtable instance" in metadata["quickstart"]
-    assert "limitations under the License" not in metadata["quickstart"]
-    # should have included additional meta-information provided.
-    assert metadata["samples"][0]["title"] == "Metadata Example 1"
-    assert metadata["samples"][0]["usage"] == "node hello-world.js"
-    assert metadata["samples"][1]["title"] == "Metadata Example 2"
-    assert metadata["samples"][1]["usage"] == "node goodnight-moon.js"
-
-    os.chdir(cwd)
-
-
 def test_syntax_highlighter():
     t = templates.Templates(NODE_TEMPLATES)
     result = t.render(


### PR DESCRIPTION
This is part 2 of the template refactoring:
* refactors node_templates to use the samples/snippets modules
* adds samples/snippets handling to Java README templates